### PR TITLE
refactor: refactor Gemini API URL to use a constant.

### DIFF
--- a/src/app/actions/analysis.ts
+++ b/src/app/actions/analysis.ts
@@ -3,9 +3,10 @@
 import { db, hasDatabaseUrl } from "@/db";
 import { analysisResults, telemetryEvents } from "@/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { ANALYSIS_MODEL_ID } from "@/lib/constants";
 
 const GEMINI_API_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
+  `https://generativelanguage.googleapis.com/v1beta/models/${ANALYSIS_MODEL_ID}:generateContent`;
 
 export const analyzeSession = async (sessionId: string) => {
   if (!sessionId) {


### PR DESCRIPTION
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2FnZDd2aDd4cjE3OGhrcTNibXI5MDFiYXdrazVxbTlqZGI0NTdmaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/YfFbDWIBXppNoMAKlW/giphy.gif)

This pull request updates the way the Gemini API URL is constructed in the `analyzeSession` action. Instead of hardcoding the model name, it now uses the `ANALYSIS_MODEL_ID` constant, making the API endpoint configurable and more maintainable.

API configuration improvement:

* Updated the Gemini API URL in `src/app/actions/analysis.ts` to use the `ANALYSIS_MODEL_ID` constant instead of a hardcoded model name, allowing for easier model updates and better configuration management.